### PR TITLE
fix(seo): update all domain references to www.lmgpt4u.com

### DIFF
--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -13,8 +13,8 @@ export const DEFAULT_SEO: SEOData = {
   title: 'Let Me GPT That For You',
   description: 'For all those people who find it more convenient to ask you rather than ChatGPT',
   keywords: 'AI chat, ChatGPT links, AI demo, artificial intelligence, share AI responses, ChatGPT demo, AI tool, free AI',
-  canonical: 'https://letmegptthatforyou.com/',
-  ogImage: 'https://letmegptthatforyou.com/og-image.png',
+  canonical: 'https://www.lmgpt4u.com/',
+  ogImage: 'https://www.lmgpt4u.com/og-image.png',
   ogType: 'website',
   twitterCard: 'summary_large_image',
   robots: 'index, follow'
@@ -22,7 +22,7 @@ export const DEFAULT_SEO: SEOData = {
 
 export const SITE_CONFIG = {
   siteName: 'Let Me GPT That For You',
-  siteUrl: 'https://letmegptthatforyou.com',
+  siteUrl: 'https://www.lmgpt4u.com',
   author: 'Jordan Garrison',
   authorUrl: 'https://jordangarrison.dev',
   twitterHandle: '@jordangarrison',

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -22,7 +22,7 @@
       "@context": "https://schema.org",
       "@type": "WebApplication",
       "name": "Let Me GPT That For You",
-      "url": "https://letmegptthatforyou.com",
+      "url": "https://www.lmgpt4u.com",
       "description": "For all those people who find it more convenient to ask you rather than ChatGPT",
       "applicationCategory": "Utility",
       "operatingSystem": "Web Browser",

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,14 +2,14 @@
   <title>Let Me GPT That For You - For all those people who find it more convenient to ask you rather than ChatGPT</title>
   <meta name="description" content="For all those people who find it more convenient to ask you rather than ChatGPT" />
   <meta name="keywords" content="AI chat, ChatGPT links, AI demo, artificial intelligence, share AI responses, ChatGPT demo, AI tool, free AI" />
-  <link rel="canonical" href="https://letmegptthatforyou.com/" />
+  <link rel="canonical" href="https://www.lmgpt4u.com/" />
   
   <!-- Open Graph tags -->
   <meta property="og:title" content="Let Me GPT That For You" />
   <meta property="og:description" content="For all those people who find it more convenient to ask you rather than ChatGPT" />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://letmegptthatforyou.com/" />
-  <meta property="og:image" content="https://letmegptthatforyou.com/og-image.png" />
+  <meta property="og:url" content="https://www.lmgpt4u.com/" />
+  <meta property="og:image" content="https://www.lmgpt4u.com/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
   <meta property="og:image:alt" content="Let Me GPT That For You - AI Chat Link Generator" />
@@ -17,7 +17,7 @@
   <!-- Twitter Card tags -->
   <meta name="twitter:title" content="Let Me GPT That For You" />
   <meta name="twitter:description" content="For all those people who find it more convenient to ask you rather than ChatGPT" />
-  <meta name="twitter:image" content="https://letmegptthatforyou.com/og-image.png" />
+  <meta name="twitter:image" content="https://www.lmgpt4u.com/og-image.png" />
   <meta name="twitter:image:alt" content="Let Me GPT That For You - AI Chat Link Generator" />
   
   <!-- Structured Data for Homepage -->
@@ -27,7 +27,7 @@
       "@type": "WebApplication",
       "name": "Let Me GPT That For You",
       "alternateName": "LetMeGPT",
-      "url": "https://letmegptthatforyou.com",
+      "url": "https://www.lmgpt4u.com",
       "description": "For all those people who find it more convenient to ask you rather than ChatGPT",
       "applicationCategory": "UtilitiesApplication",
       "operatingSystem": "Web Browser",
@@ -49,7 +49,7 @@
         "No registration required",
         "Instant link generation"
       ],
-      "screenshot": "https://letmegptthatforyou.com/screenshot.png",
+      "screenshot": "https://www.lmgpt4u.com/screenshot.png",
       "softwareVersion": "1.0",
       "datePublished": "2024-01-01",
       "dateModified": "2024-01-01"

--- a/src/routes/chat/[provider]/+page.ts
+++ b/src/routes/chat/[provider]/+page.ts
@@ -35,8 +35,8 @@ export const load: PageLoad = ({ params, url }) => {
       description: query 
         ? `Automatically redirecting to ${currentProvider.name} to answer: "${query.slice(0, 120)}${query.length > 120 ? '...' : ''}"`
         : `Automatically redirecting to ${currentProvider.name} - ${currentProvider.description}`,
-      canonicalUrl: `https://letmegptthatforyou.com/chat/${provider}${query ? `?q=${encodeURIComponent(query)}` : ''}`,
-      ogImage: 'https://letmegptthatforyou.com/og-image-chat.png'
+      canonicalUrl: `https://www.lmgpt4u.com/chat/${provider}${query ? `?q=${encodeURIComponent(query)}` : ''}`,
+      ogImage: 'https://www.lmgpt4u.com/og-image-chat.png'
     }
   };
 };

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from '@sveltejs/kit';
 
 export const GET: RequestHandler = async () => {
-  const baseUrl = 'https://letmegptthatforyou.com';
+  const baseUrl = 'https://www.lmgpt4u.com';
   
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -5,7 +5,7 @@ Disallow: /chat/*
 # Allow indexing of main pages but not individual chat redirects
 # since they're temporary redirect pages
 
-Sitemap: https://letmegptthatforyou.com/sitemap.xml
+Sitemap: https://www.lmgpt4u.com/sitemap.xml
 
 # Crawl-delay for better server performance
 Crawl-delay: 1


### PR DESCRIPTION
## 🔧 Fix Domain URLs in SEO Configuration

This PR fixes all domain references throughout the SEO configuration to use the correct production domain `www.lmgpt4u.com` instead of the placeholder `letmegptthatforyou.com`.

## 🐛 Problem

The SEO implementation was using incorrect domain URLs:
- Sitemap was pointing to `https://letmegptthatforyou.com/sitemap.xml`
- Meta tags, Open Graph, and structured data were using wrong URLs
- Canonical URLs were incorrect for production

## ✅ Solution

Updated all domain references to use `https://www.lmgpt4u.com`:

### Files Changed
- **`src/routes/sitemap.xml/+server.ts`** - Updated baseUrl for sitemap generation
- **`static/robots.txt`** - Fixed sitemap reference URL
- **`src/lib/seo.ts`** - Updated default canonical URL and Open Graph image URLs
- **`src/routes/+page.svelte`** - Fixed all meta tags, Open Graph, and structured data URLs
- **`src/routes/+layout.svelte`** - Updated structured data site URL
- **`src/routes/chat/[provider]/+page.ts`** - Fixed canonical URLs and Open Graph images for chat pages

### SEO Benefits
✅ Correct canonical URLs for better search engine indexing  
✅ Proper sitemap URL in robots.txt  
✅ Accurate Open Graph images for social media sharing  
✅ Consistent domain references across all meta tags  
✅ Valid structured data with correct site URLs  

## 🧪 Testing

- ✅ Build passes successfully
- ✅ All URLs now consistently use `https://www.lmgpt4u.com`
- ✅ Sitemap will be accessible at `https://www.lmgpt4u.com/sitemap.xml`
- ✅ Robots.txt correctly points to sitemap

## 📋 Verification

After deployment, verify:
- [ ] `https://www.lmgpt4u.com/sitemap.xml` is accessible
- [ ] `https://www.lmgpt4u.com/robots.txt` shows correct sitemap URL
- [ ] Social media sharing shows correct Open Graph images
- [ ] Search engines can properly crawl the site

---

**Ready for immediate merge** - This is a critical fix for proper SEO functionality in production! 🚀